### PR TITLE
[nrf noup] boot: zephyr: Fix build issue with BOOT_UPGRADE_ONLY mode

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -831,8 +831,14 @@ boot_validated_swap_type(struct boot_loader_state *state,
                 swap_type = BOOT_SWAP_TYPE_FAIL;
             } else {
                 BOOT_LOG_INF("Done updating network core");
+#if defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE)
+                /* swap_erase_trailer_sectors is undefined if upgrade only
+                 * method is used. There is no need to erase sectors, because
+                 * the image cannot be reverted.
+                 */
                 rc = swap_erase_trailer_sectors(state,
                         secondary_fa);
+#endif
                 swap_type = BOOT_SWAP_TYPE_NONE;
             }
         }


### PR DESCRIPTION
This patch fixes build issue when mcuboot image upgrade mode
is set to BOOT_UPGRADE_ONLY for nrf53 SoC.

swap_erase_trailer_sectors is not defined if used with above
update method. There is no need to erase sectors, because
the image can not be reverted.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>